### PR TITLE
Harden runtime data loading and audio handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# 项目协作规则
+
+本文件适用于整个仓库。修改子目录时，如存在更具体的 `AGENTS.md`，以更具体的规则为准。
+
+## 工程约定
+
+- 项目使用 C++17 和 CMake，需保持 GCC 8+、Clang 7+、MSVC 2019+ 兼容性。
+- 源码格式遵循 `src/.clang-format`：4 空格缩进、禁用 Tab、右侧指针对齐、不限制行宽。
+- 不修改 `deps/` 中的第三方代码，除非任务明确要求升级或修补依赖。
+- 搜索文件和文本时优先使用 `rg` 与 `rg --files`。
+- 工作区可能包含其他未提交修改；不得覆盖、还原或删除不属于当前任务的改动。
+
+## Windows UCRT64 环境
+
+MSYS2 安装在 `C:\msys64`。执行 CMake、编译产物或 CTest 前，必须将 UCRT64 运行库目录放到 PATH 最前面：
+
+```powershell
+$env:PATH='C:\msys64\ucrt64\bin;' + $env:PATH
+```
+
+缺少该设置时，MinGW 可执行文件可能无诊断退出，测试进程也可能停留在不可见的 DLL 错误对话框中。
+
+常用验证命令：
+
+```powershell
+$env:PATH='C:\msys64\ucrt64\bin;' + $env:PATH
+cmake --build cmake-build-debug --config Debug
+ctest --test-dir cmake-build-debug -C Debug --output-on-failure
+cmake --build cmake-build-release --config Release
+ctest --test-dir cmake-build-release -C Release --output-on-failure
+git diff --check
+```
+
+首次创建构建目录时启用测试：
+
+```powershell
+cmake -S . -B cmake-build-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON
+cmake -S . -B cmake-build-release -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+```
+
+`src/CMakeLists.txt` 使用 `file(GLOB ...)` 收集源码。新增 `*.cc` 或 `*.hh` 后，需要重新运行 CMake 配置，再执行构建。
+
+## 实现要求
+
+- 资源、存档和二进制数据加载必须校验文件长度、元素对齐、偏移范围、短读及整数溢出。
+- 解析外部数据时先写入临时对象；全部验证成功后再更新全局或现有状态，失败时保留原状态。
+- 修改 IDX/GRP、存档、事件或战场格式时，需兼容原版数据约定，并为损坏输入和失败回滚补充测试。
+- SDL 音频长度进入 `int` API 前必须检查范围；检查 SDL 转换、分配和设备初始化的返回值。
+- 音频回调共享的数据必须使用同一互斥量保护；重新初始化设备时清理依赖旧设备格式的声道和缓存。
+- 必需配置或核心资源加载失败时应返回失败状态，避免进入窗口和场景初始化。
+
+## 测试与提交
+
+- 修复缺陷时添加覆盖原始失败条件的回归测试，并验证失败路径不会污染既有状态。
+- 至少运行受影响的测试；涉及公共加载、启动、音频或构建逻辑时，运行 Debug 和 Release 全量测试。
+- Release 构建可能出现来自 `libADLMIDI`、`fmt` 或既有场景代码的 LTO/ODR 警告。不得把既有第三方警告误判为当前修改，但新增警告需要处理。
+- 提交前检查 `git status --short`、`git diff --check` 和暂存差异，避免提交构建产物、凭据或无关文件。
+- 提交信息采用 Conventional Commits，使用简短的祈使句描述实际修改。

--- a/src/audio/channel.cc
+++ b/src/audio/channel.cc
@@ -59,7 +59,7 @@ size_t Channel::readData(void *data, size_t size) {
     const void *pcmdata;
     auto res = readPCMData(&pcmdata, size, true);
     if (res) {
-        memcpy(data, pcmdata, size);
+        memcpy(data, pcmdata, res);
     }
     return res;
 }

--- a/src/audio/channelwav.cc
+++ b/src/audio/channelwav.cc
@@ -21,22 +21,35 @@
 
 #include <SDL.h>
 
+#include <limits>
+
 namespace hojy::audio {
+
+namespace {
+
+bool checkedConversionSize(size_t inputSize, int multiplier, size_t &outputSize) {
+    if (multiplier <= 0
+        || inputSize > static_cast<size_t>(std::numeric_limits<int>::max()) / static_cast<size_t>(multiplier)) {
+        return false;
+    }
+    outputSize = inputSize * static_cast<size_t>(multiplier);
+    return true;
+}
+
+}
 
 ChannelWav::ChannelWav(Mixer *mixer, const std::string &filename) : Channel(mixer, filename) {
     if (ok_) { loadFromData(); }
 }
 
 ChannelWav::~ChannelWav() {
-    if (buffer_) {
-        SDL_FreeWAV(buffer_);
-    }
+    clearBuffer();
 }
 
 void ChannelWav::load(const std::string &filename) {
+    clearBuffer();
     Channel::load(filename);
     if (!ok_) { return; }
-    reset();
     loadFromData();
 }
 
@@ -50,6 +63,7 @@ size_t ChannelWav::readPCMData(const void **data, size_t size, bool convType) {
     }
     if (repeat_) {
         if (!length_) { return 0; }
+        if (pos_ >= length_) { reset(); }
         if (pos_ + size <= length_) {
             *data = buffer_ + pos_;
             pos_ = (pos_ + size) % length_;
@@ -65,6 +79,7 @@ size_t ChannelWav::readPCMData(const void **data, size_t size, bool convType) {
                 if (pos_ + left >= length_) {
                     auto readsz = length_ - pos_;
                     memcpy(writedata, buffer_ + pos_, readsz);
+                    writedata += readsz;
                     left -= readsz;
                     reset();
                 } else {
@@ -86,45 +101,84 @@ size_t ChannelWav::readPCMData(const void **data, size_t size, bool convType) {
     if (!needConv) {
         return size;
     }
-    SDL_AudioCVT cvt;
-    SDL_BuildAudioCVT(&cvt, Mixer::convertType(typeIn_), 2, int(sampleRateIn_),
-                      Mixer::convertType(typeOut_), 2, int(sampleRateIn_));
-    int osize = int(size * cvt.len_mult);
-    int smax = std::max<int>(size, osize);
+    if (size > std::numeric_limits<int>::max()) { return 0; }
+    SDL_AudioCVT cvt{};
+    if (SDL_BuildAudioCVT(&cvt, Mixer::convertType(typeIn_), 2, int(sampleRateIn_),
+                          Mixer::convertType(typeOut_), 2, int(sampleRateIn_)) < 0) {
+        return 0;
+    }
+    size_t outputSize = 0;
+    if (!checkedConversionSize(size, cvt.len_mult, outputSize)) { return 0; }
+    auto smax = std::max(size, outputSize);
     if (cache_.size() < smax) {
         cache_.resize(smax);
     }
     if (needCopy) {
         memcpy(cache_.data(), *data, size);
     }
-    cvt.len = size;
+    cvt.len = static_cast<int>(size);
     cvt.buf = cache_.data();
-    SDL_ConvertAudio(&cvt);
+    if (SDL_ConvertAudio(&cvt) < 0) { return 0; }
     *data = cache_.data();
     return cvt.len_cvt;
 }
 
-void ChannelWav::loadFromData() {
-    SDL_AudioSpec spec;
-    if (SDL_LoadWAV_RW(SDL_RWFromConstMem(data_.data(), data_.size()),
-                       1, &spec, &buffer_, &length_)) {
-        sampleRateIn_ = spec.freq;
-        auto format = spec.format;
-        if (spec.channels != 2 || (format != AUDIO_F32 && format != AUDIO_S32 && format != AUDIO_S16)) {
-            SDL_AudioCVT cvt;
-            format = format != AUDIO_F32 && format != AUDIO_S32 && format != AUDIO_S16 ? AUDIO_S16 : format;
-            SDL_BuildAudioCVT(&cvt, spec.format, spec.channels, spec.freq, format, 2, spec.freq);
-            cvt.len = length_;
-            buffer_ = static_cast<Uint8*>(SDL_realloc(buffer_, length_ * cvt.len_mult));
-            cvt.buf = buffer_;
-            SDL_ConvertAudio(&cvt);
-            length_ = cvt.len_cvt;
-        }
-        typeIn_ = Mixer::convertDataType(format);
-        ok_ = true;
-    } else {
-        ok_ = false;
+void ChannelWav::clearBuffer() {
+    if (buffer_) {
+        SDL_FreeWAV(buffer_);
+        buffer_ = nullptr;
     }
+    length_ = 0;
+    pos_ = 0;
+}
+
+void ChannelWav::loadFromData() {
+    clearBuffer();
+    if (data_.size() > std::numeric_limits<int>::max()) {
+        ok_ = false;
+        return;
+    }
+    SDL_AudioSpec spec{};
+    auto *source = SDL_RWFromConstMem(data_.data(), static_cast<int>(data_.size()));
+    if (!source || !SDL_LoadWAV_RW(source, 1, &spec, &buffer_, &length_)) {
+        ok_ = false;
+        return;
+    }
+    sampleRateIn_ = spec.freq;
+    auto format = spec.format;
+    if (spec.channels != 2 || (format != AUDIO_F32 && format != AUDIO_S32 && format != AUDIO_S16)) {
+        SDL_AudioCVT cvt{};
+        format = format != AUDIO_F32 && format != AUDIO_S32 && format != AUDIO_S16 ? AUDIO_S16 : format;
+        if (SDL_BuildAudioCVT(&cvt, spec.format, spec.channels, spec.freq, format, 2, spec.freq) < 0) {
+            clearBuffer();
+            ok_ = false;
+            return;
+        }
+        size_t convertedSize = 0;
+        if (!checkedConversionSize(length_, cvt.len_mult, convertedSize)) {
+            clearBuffer();
+            ok_ = false;
+            return;
+        }
+        auto *converted = static_cast<Uint8*>(SDL_realloc(buffer_, convertedSize));
+        if (!converted) {
+            clearBuffer();
+            ok_ = false;
+            return;
+        }
+        buffer_ = converted;
+        cvt.len = static_cast<int>(length_);
+        cvt.buf = buffer_;
+        if (SDL_ConvertAudio(&cvt) < 0) {
+            clearBuffer();
+            ok_ = false;
+            return;
+        }
+        length_ = static_cast<std::uint32_t>(cvt.len_cvt);
+    }
+    typeIn_ = Mixer::convertDataType(format);
+    ok_ = typeIn_ != Mixer::InvalidType;
+    if (!ok_) { clearBuffer(); }
 }
 
 }

--- a/src/audio/channelwav.hh
+++ b/src/audio/channelwav.hh
@@ -36,6 +36,7 @@ protected:
     size_t readPCMData(const void **data, size_t size, bool convType) override;
 
 private:
+    void clearBuffer();
     void loadFromData();
 
 private:

--- a/src/audio/mixer.cc
+++ b/src/audio/mixer.cc
@@ -35,13 +35,25 @@ void Mixer::ChannelInfo::reset() {
 }
 
 Mixer::~Mixer() {
-    SDL_CloseAudioDevice(audioDevice_);
+    if (audioDevice_ != 0) {
+        SDL_CloseAudioDevice(audioDevice_);
+    }
 }
 
-void Mixer::init(int channels) {
-    if (!SDL_WasInit(SDL_INIT_AUDIO)) {
-        SDL_InitSubSystem(SDL_INIT_AUDIO);
+bool Mixer::init(int channels) {
+    if (channels <= 0) { return false; }
+    if (!SDL_WasInit(SDL_INIT_AUDIO) && SDL_InitSubSystem(SDL_INIT_AUDIO) < 0) {
+        SDL_Log("Unable to initialize audio: %s", SDL_GetError());
+        return false;
     }
+    if (audioDevice_ != 0) {
+        SDL_CloseAudioDevice(audioDevice_);
+        audioDevice_ = 0;
+    }
+    sampleRate_ = 0;
+    format_ = 0;
+    channels_.clear();
+    cache_.clear();
     SDL_AudioFormat format;
 #if defined(USE_SOXR)
     switch (core::config.sampleFormat()) {
@@ -58,25 +70,33 @@ void Mixer::init(int channels) {
 #else
     format = AUDIO_F32;
 #endif
-    SDL_AudioSpec desired = {
-        core::config.sampleRate(),
-        format,
-        2,
-        0,
-        2048,
-        0,
-        0,
-        callback,
-        this,
-    };
-    SDL_AudioSpec obtained;
-    if (!(audioDevice_ = SDL_OpenAudioDevice(nullptr, 0, &desired, &obtained, SDL_AUDIO_ALLOW_CHANNELS_CHANGE))) {
-        audioDevice_ = SDL_OpenAudioDevice(nullptr, 0, &desired, &obtained, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE | SDL_AUDIO_ALLOW_CHANNELS_CHANGE);
+    SDL_AudioSpec desired{};
+    desired.freq = core::config.sampleRate();
+    desired.format = format;
+    desired.channels = 2;
+    desired.samples = 2048;
+    desired.callback = callback;
+    desired.userdata = this;
+    SDL_AudioSpec obtained{};
+    audioDevice_ = SDL_OpenAudioDevice(nullptr, 0, &desired, &obtained, 0);
+    if (audioDevice_ == 0) {
+        audioDevice_ = SDL_OpenAudioDevice(nullptr, 0, &desired, &obtained, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+    }
+    if (audioDevice_ == 0) {
+        SDL_Log("Unable to open audio device: %s", SDL_GetError());
+        return false;
+    }
+    if (obtained.channels != 2 || convertDataType(obtained.format) == InvalidType) {
+        SDL_Log("Unsupported audio format returned by device");
+        SDL_CloseAudioDevice(audioDevice_);
+        audioDevice_ = 0;
+        return false;
     }
     sampleRate_ = obtained.freq;
     format_ = obtained.format;
     channels_.resize(channels);
     cache_.resize(obtained.size);
+    return true;
 }
 
 void Mixer::play(size_t channelId, Channel *ch, int volume, std::uint32_t fadeOutMs, std::uint32_t fadeInMs) {
@@ -196,10 +216,13 @@ void Mixer::play(size_t channelId, const std::string &filename, bool repeat, int
 }
 
 void Mixer::pause(bool on) const {
-    SDL_PauseAudioDevice(audioDevice_, on ? SDL_TRUE : SDL_FALSE);
+    if (audioDevice_ != 0) {
+        SDL_PauseAudioDevice(audioDevice_, on ? SDL_TRUE : SDL_FALSE);
+    }
 }
 
 void Mixer::setVolume(size_t channelId, int volume) {
+    std::scoped_lock lk(playMutex_);
     if (channelId >= channels_.size()) { return; }
     auto &chi = channels_[channelId];
     if (!chi.ch) { return; }
@@ -250,7 +273,6 @@ void Mixer::callback(void *userdata, std::uint8_t *stream, int len) {
     std::scoped_lock lk(mixer->playMutex_);
     auto &cache = mixer->cache_;
     auto &channels = mixer->channels_;
-    auto &chi0 = channels[0];
     memset(stream, 0, len);
     for (auto &chi: channels) {
         if (!chi.ch) { continue; }

--- a/src/audio/mixer.hh
+++ b/src/audio/mixer.hh
@@ -55,7 +55,7 @@ public:
     };
 
     ~Mixer();
-    void init(int channels);
+    [[nodiscard]] bool init(int channels);
 
     void play(size_t channelId, Channel *ch, int volume = VolumeMax, std::uint32_t fadeOutMs = 0, std::uint32_t fadeInMs = 0);
     void play(size_t channelId, const std::string &filename, bool repeat, int volume = VolumeMax, std::uint32_t fadeOutMs = 0, std::uint32_t fadeInMs = 0);

--- a/src/core/config.cc
+++ b/src/core/config.cc
@@ -33,9 +33,19 @@ namespace hojy::core {
 Config config;
 
 bool Config::load(const std::string &filename) {
+    auto file = util::File::open(filename);
+    if (!file) {
+        fmt::print(stderr, "Unable to open config file: {}\n", filename);
+        return false;
+    }
+    std::string content(static_cast<size_t>(file.size()), '\0');
+    if (!content.empty() && file.read(content.data(), content.size()) != content.size()) {
+        fmt::print(stderr, "Unable to read config file: {}\n", filename);
+        return false;
+    }
     toml::table tbl;
     try {
-        tbl = toml::parse(util::File::getFileContent(filename));
+        tbl = toml::parse(content);
     } catch (const toml::parse_error &err) {
         fmt::print("Parsing failed: {}\n", err.description());
         return false;
@@ -48,11 +58,14 @@ bool Config::load(const std::string &filename) {
             dataPath_.resize(1);
             dataPath_[0] = dpath.value_or<std::string>(".");
         } else if (dpath.is_array()) {
+            dataPath_.clear();
             for (auto &p : *dpath.as_array()) {
                 dataPath_.emplace_back(p.value_or<std::string>("."));
             }
         }
-        dataPath_[0] = prePath_ + dataPath_[0];
+        if (!dataPath_.empty()) {
+            dataPath_[0] = prePath_ + dataPath_[0];
+        }
         musicPath_ = prePath_ + main["music_path"].value_or(std::move(musicPath_));
         soundPath_ = prePath_ + main["sound_path"].value_or(std::move(soundPath_));
         savePath_ = prePath_ + main["save_path"].value_or(std::move(savePath_));
@@ -60,11 +73,14 @@ bool Config::load(const std::string &filename) {
         if (fonts.is_string()) {
             fonts_ = {fonts.value_or<std::string>("")};
         } else if (fonts.is_array()) {
+            fonts_.clear();
             for (auto &p : *fonts.as_array()) {
                 fonts_.emplace_back(p.value_or<std::string>(""));
             }
         }
-        fonts_[0] = prePath_ + fonts_[0];
+        if (!fonts_.empty()) {
+            fonts_[0] = prePath_ + fonts_[0];
+        }
         shipLogicEnabled_ = main["ship_logic_enabled"].value_or<bool>(std::forward<bool>(shipLogicEnabled_));
     }
     auto window = tbl["window"];
@@ -141,6 +157,10 @@ bool Config::saveOptions(const std::string &filename) const {
 }
 
 bool Config::postLoad() {
+    if (dataPath_.empty() || fonts_.empty()) {
+        fmt::print(stderr, "Config must define non-empty main.data_path and main.fonts values.\n");
+        return false;
+    }
     if (limitFPS_ == 0) { limitFPS_ = 60; }
     musicVolume_ = std::clamp(musicVolume_, 0, 8);
     soundVolume_ = std::clamp(soundVolume_, 0, 8);

--- a/src/core/resourcemgr.cc
+++ b/src/core/resourcemgr.cc
@@ -28,6 +28,10 @@ namespace hojy::core {
 ResourceMgr gResourceMgr;
 
 void ResourceMgr::init() {
+    files_.clear();
+    missingFiles_.clear();
+    missingFilesOpt_.clear();
+
     const std::set<std::string, StringCaseInsensitiveLess> dataFiles = {
         /* strings.toml */
         "strings.toml",
@@ -101,26 +105,35 @@ void ResourceMgr::init() {
     auto fn = [this](const std::string &path,
                      const std::set<std::string, StringCaseInsensitiveLess> &sset,
                      const std::set<std::string, StringCaseInsensitiveLess> &sset2) {
-        for (auto &p: std::filesystem::directory_iterator(path)) {
-            if (!p.is_regular_file()) { continue; }
+        std::error_code ec;
+        std::filesystem::directory_iterator ite(path, ec), end;
+        while (!ec && ite != end) {
+            const auto &p = *ite;
+            if (!p.is_regular_file(ec)) {
+                ec.clear();
+                ite.increment(ec);
+                continue;
+            }
             auto filename = p.path().filename().string();
             if (files_.find(filename) != files_.end()) {
+                ite.increment(ec);
                 continue;
             }
             {
-                auto ite = sset.find(filename);
-                if (ite != sset.end()) {
-                    files_[*ite] = p.path().string();
+                auto file = sset.find(filename);
+                if (file != sset.end()) {
+                    files_[*file] = p.path().string();
+                    ite.increment(ec);
                     continue;
                 }
             }
             if (!sset2.empty()) {
-                auto ite = sset2.find(filename);
-                if (ite != sset2.end()) {
-                    files_[*ite] = p.path().string();
-                    continue;
+                auto file = sset2.find(filename);
+                if (file != sset2.end()) {
+                    files_[*file] = p.path().string();
                 }
             }
+            ite.increment(ec);
         }
     };
     for (auto &path: config.dataPath()) {

--- a/src/core/resourcemgr.hh
+++ b/src/core/resourcemgr.hh
@@ -43,7 +43,7 @@ class ResourceMgr {
 public:
     void init();
     [[nodiscard]] const std::set<std::string> &missingFiles() const { return missingFiles_; }
-    [[nodiscard]] const std::set<std::string> &missingFilesOpt() const { return missingFiles_; }
+    [[nodiscard]] const std::set<std::string> &missingFilesOpt() const { return missingFilesOpt_; }
     [[nodiscard]] const std::string &getFilePath(const std::string &file) const;
 
 private:

--- a/src/data/event.cc
+++ b/src/data/event.cc
@@ -23,38 +23,48 @@
 #include "core/config.hh"
 #include "util/conv.hh"
 #include <cstring>
+#include <utility>
 
 namespace hojy::data {
 
 Event gEvent;
 
-void Event::loadEvent(const std::string &name) {
+bool Event::loadEvent(const std::string &name) {
     GrpData::DataSet dset;
-    if (!GrpData::loadData(name, dset)) { return; }
+    if (!GrpData::loadData(name, dset)) { return false; }
     auto sz = dset.size();
-    events_.resize(sz);
+    std::vector<std::vector<std::int16_t>> events(sz);
     for (size_t i = 0; i < sz; ++i) {
-        events_[i].resize(dset[i].size() / sizeof(std::int16_t));
-        memcpy(events_[i].data(), dset[i].data(), dset[i].size());
+        if (dset[i].size() % sizeof(std::int16_t) != 0) { return false; }
+        events[i].resize(dset[i].size() / sizeof(std::int16_t));
+        if (!dset[i].empty()) {
+            memcpy(events[i].data(), dset[i].data(), dset[i].size());
+        }
     }
+    events_ = std::move(events);
+    return true;
 }
 
-void Event::loadTalk(const std::string &name) {
-    if (!GrpData::loadData(name, origTalks_)) { return; }
-    auto sz = origTalks_.size();
-    talks_.resize(sz);
+bool Event::loadTalk(const std::string &name) {
+    GrpData::DataSet origTalks;
+    if (!GrpData::loadData(name, origTalks)) { return false; }
+    auto sz = origTalks.size();
+    std::vector<std::wstring> talks(sz);
     for (size_t i = 0; i < sz; ++i) {
-        auto &t = origTalks_[i];
+        auto &t = origTalks[i];
         for (auto &c: t) {
             if (c) { c = ~c; }
         }
-        talks_[i] = util::big5Conv.toUnicode(t.c_str());
+        talks[i] = util::big5Conv.toUnicode(t.c_str());
     }
     if (core::config.simplifiedChinese()) {
-        for (auto &t: talks_) {
+        for (auto &t: talks) {
             t = util::trad2SimpConv.convert(t);
         }
     }
+    origTalks_ = std::move(origTalks);
+    talks_ = std::move(talks);
+    return true;
 }
 
 const std::vector<std::int16_t> &Event::event(size_t index) const {

--- a/src/data/event.hh
+++ b/src/data/event.hh
@@ -27,8 +27,8 @@ namespace hojy::data {
 
 class Event {
 public:
-    void loadEvent(const std::string &name);
-    void loadTalk(const std::string &name);
+    [[nodiscard]] bool loadEvent(const std::string &name);
+    [[nodiscard]] bool loadTalk(const std::string &name);
 
     [[nodiscard]] const std::vector<std::int16_t> &event(size_t index) const;
     [[nodiscard]] const std::string &origTalk(size_t index) const;

--- a/src/data/factors.cc
+++ b/src/data/factors.cc
@@ -26,49 +26,41 @@ namespace hojy::data {
 
 Factors gFactors;
 
-void Factors::load(const std::string &filename) {
+bool Factors::load(const std::string &filename) {
     auto file = util::File::open(core::config.dataFilePath(filename));
-    if (!file) { return; }
+    if (!file) { return false; }
+    Factors loaded{};
+    auto readAt = [&file](std::uint64_t offset, void *data, size_t size) {
+        return file.seek(offset) == offset && file.read(data, size) == size;
+    };
     if (file.size() == 0x5F000) {
         /* Z.DAT from swimmingfish's FishEdit 0.72 */
-        file.seek(0x20ce5);
-        file.read(leaveTeamChars.data(), sizeof(std::int16_t) * leaveTeamChars.size());
-        file.seek(0x25cc6);
-        file.read(&leaveTeamStartEvents, sizeof(std::int16_t));
-        file.seek(0x26d6e);
-        file.read(&initSubMapId, sizeof(std::int16_t));
-        file.seek(0x26db7);
-        file.read(&initSubMapX, sizeof(std::int16_t));
-        file.seek(0x26dc0);
-        file.read(&initSubMapY, sizeof(std::int16_t));
-        file.seek(0x26e2e);
-        file.read(&initMainCharTex, sizeof(std::int16_t));
-        file.seek(0x5b43a);
-        file.read(expForLevelUp.data(), sizeof(std::uint16_t) * expForLevelUp.size());
-        file.seek(0x5b36c);
-        file.read(effectFrames.data(), sizeof(std::int16_t) * effectFrames.size());
-        file.seek(0x5b110);
-        file.read(skillWeaponsBindings.data(), sizeof(std::int16_t) * skillWeaponsBindings.size());
+        if (!readAt(0x20ce5, loaded.leaveTeamChars.data(), sizeof(std::int16_t) * loaded.leaveTeamChars.size())
+            || !readAt(0x25cc6, &loaded.leaveTeamStartEvents, sizeof(std::int16_t))
+            || !readAt(0x26d6e, &loaded.initSubMapId, sizeof(std::int16_t))
+            || !readAt(0x26db7, &loaded.initSubMapX, sizeof(std::int16_t))
+            || !readAt(0x26dc0, &loaded.initSubMapY, sizeof(std::int16_t))
+            || !readAt(0x26e2e, &loaded.initMainCharTex, sizeof(std::int16_t))
+            || !readAt(0x5b43a, loaded.expForLevelUp.data(), sizeof(std::uint16_t) * loaded.expForLevelUp.size())
+            || !readAt(0x5b36c, loaded.effectFrames.data(), sizeof(std::int16_t) * loaded.effectFrames.size())
+            || !readAt(0x5b110, loaded.skillWeaponsBindings.data(), sizeof(std::int16_t) * loaded.skillWeaponsBindings.size())) {
+            return false;
+        }
     } else {
-        file.seek(0x1a6e5);
-        file.read(leaveTeamChars.data(), sizeof(std::int16_t) * leaveTeamChars.size());
-        file.seek(0x1f6c6);
-        file.read(&leaveTeamStartEvents, sizeof(std::int16_t));
-        file.seek(0x2076e);
-        file.read(&initSubMapId, sizeof(std::int16_t));
-        file.seek(0x207b7);
-        file.read(&initSubMapX, sizeof(std::int16_t));
-        file.seek(0x207c0);
-        file.read(&initSubMapY, sizeof(std::int16_t));
-        file.seek(0x2082e);
-        file.read(&initMainCharTex, sizeof(std::int16_t));
-        file.seek(0x4df90);
-        file.read(expForLevelUp.data(), sizeof(std::uint16_t) * expForLevelUp.size());
-        file.seek(0x4f4ce);
-        file.read(effectFrames.data(), sizeof(std::int16_t) * effectFrames.size());
-        file.seek(0x4f538);
-        file.read(skillWeaponsBindings.data(), sizeof(std::int16_t) * skillWeaponsBindings.size());
+        if (!readAt(0x1a6e5, loaded.leaveTeamChars.data(), sizeof(std::int16_t) * loaded.leaveTeamChars.size())
+            || !readAt(0x1f6c6, &loaded.leaveTeamStartEvents, sizeof(std::int16_t))
+            || !readAt(0x2076e, &loaded.initSubMapId, sizeof(std::int16_t))
+            || !readAt(0x207b7, &loaded.initSubMapX, sizeof(std::int16_t))
+            || !readAt(0x207c0, &loaded.initSubMapY, sizeof(std::int16_t))
+            || !readAt(0x2082e, &loaded.initMainCharTex, sizeof(std::int16_t))
+            || !readAt(0x4df90, loaded.expForLevelUp.data(), sizeof(std::uint16_t) * loaded.expForLevelUp.size())
+            || !readAt(0x4f4ce, loaded.effectFrames.data(), sizeof(std::int16_t) * loaded.effectFrames.size())
+            || !readAt(0x4f538, loaded.skillWeaponsBindings.data(), sizeof(std::int16_t) * loaded.skillWeaponsBindings.size())) {
+            return false;
+        }
     }
+    *this = loaded;
+    return true;
 }
 
 }

--- a/src/data/factors.hh
+++ b/src/data/factors.hh
@@ -27,7 +27,7 @@
 namespace hojy::data {
 
 struct Factors {
-    void load(const std::string &filename);
+    [[nodiscard]] bool load(const std::string &filename);
 
     std::array<std::int16_t, 25> leaveTeamChars;
     std::int16_t leaveTeamStartEvents;

--- a/src/data/grpdata.cc
+++ b/src/data/grpdata.cc
@@ -22,6 +22,9 @@
 #include "core/config.hh"
 #include "util/file.hh"
 
+#include <limits>
+#include <utility>
+
 namespace hojy::data {
 
 bool GrpData::loadData(const std::string &idx, const std::string &grp, GrpData::DataSet &dset, bool isSave) {
@@ -36,23 +39,37 @@ bool GrpData::loadData(const std::string &idx, const std::string &grp, GrpData::
     if (!ifs || !ifs2) {
         return false;
     }
-    size_t count = ifs.size() / sizeof(std::uint32_t);
-    size_t fileSize = ifs2.size();
-    dset.resize(count);
+    const auto idxSize = ifs.size();
+    const auto fileSize = ifs2.size();
+    if (idxSize % sizeof(std::uint32_t) != 0
+        || fileSize > std::numeric_limits<std::uint32_t>::max()) {
+        return false;
+    }
+    const auto count = static_cast<size_t>(idxSize / sizeof(std::uint32_t));
+    DataSet loaded(count);
     std::uint32_t offset = 0;
     for (size_t i = 0; i < count; ++i) {
-        std::uint32_t endoffset;
-        ifs.read(&endoffset, sizeof(endoffset));
+        std::uint32_t endoffset = 0;
+        if (ifs.read(&endoffset, sizeof(endoffset)) != sizeof(endoffset)) {
+            return false;
+        }
         if (endoffset == 0) {
-            endoffset = fileSize;
+            if (i + 1 != count) { return false; }
+            endoffset = static_cast<std::uint32_t>(fileSize);
         }
-        if (endoffset > offset) {
-            dset[i].resize(endoffset - offset);
-            ifs2.seek(offset);
-            ifs2.read(dset[i].data(), endoffset - offset);
-            offset = endoffset;
+        if (endoffset < offset || endoffset > fileSize) {
+            return false;
         }
+        const auto size = static_cast<size_t>(endoffset - offset);
+        loaded[i].resize(size);
+        if (size > 0
+            && (ifs2.seek(offset) != offset || ifs2.read(loaded[i].data(), size) != size)) {
+            return false;
+        }
+        offset = endoffset;
     }
+    if (offset != fileSize) { return false; }
+    dset = std::move(loaded);
     return true;
 }
 
@@ -61,6 +78,18 @@ bool GrpData::loadData(const std::string &name, GrpData::DataSet &dset, bool isS
 }
 
 bool GrpData::saveData(const std::string &name, const GrpData::DataSet &dset, bool isSave) {
+    std::uint64_t totalSize = 0;
+    for (size_t i = 0; i < dset.size(); ++i) {
+        const auto &data = dset[i];
+        totalSize += data.size();
+        if (totalSize > std::numeric_limits<std::uint32_t>::max()) {
+            return false;
+        }
+        if (totalSize == 0 && i + 1 != dset.size()) {
+            return false;
+        }
+    }
+
     util::File ifs, ifs2;
     if (isSave) {
         ifs = util::File::create(core::config.saveFilePath(name + ".IDX"));
@@ -74,9 +103,11 @@ bool GrpData::saveData(const std::string &name, const GrpData::DataSet &dset, bo
     }
     std::uint32_t offset = 0;
     for (auto &d: dset) {
-        offset += d.size();
-        ifs2.write(d.data(), d.size());
-        ifs.write(&offset, sizeof(std::uint32_t));
+        offset += static_cast<std::uint32_t>(d.size());
+        if ((d.size() > 0 && ifs2.write(d.data(), d.size()) != d.size())
+            || ifs.write(&offset, sizeof(std::uint32_t)) != sizeof(std::uint32_t)) {
+            return false;
+        }
     }
     return true;
 }

--- a/src/data/grpdata.cc
+++ b/src/data/grpdata.cc
@@ -48,14 +48,17 @@ bool GrpData::loadData(const std::string &idx, const std::string &grp, GrpData::
     const auto count = static_cast<size_t>(idxSize / sizeof(std::uint32_t));
     DataSet loaded(count);
     std::uint32_t offset = 0;
+    bool reachedEnd = false;
     for (size_t i = 0; i < count; ++i) {
         std::uint32_t endoffset = 0;
         if (ifs.read(&endoffset, sizeof(endoffset)) != sizeof(endoffset)) {
             return false;
         }
         if (endoffset == 0) {
-            if (i + 1 != count) { return false; }
+            reachedEnd = true;
             endoffset = static_cast<std::uint32_t>(fileSize);
+        } else if (reachedEnd) {
+            return false;
         }
         if (endoffset < offset || endoffset > fileSize) {
             return false;

--- a/src/data/loader.cc
+++ b/src/data/loader.cc
@@ -25,11 +25,11 @@
 
 namespace hojy::data {
 
-void loadData() {
-    gFactors.load("Z.DAT");
-    gEvent.loadEvent("KDEF");
-    gEvent.loadTalk("TALK");
-    gWarfieldData.load("WAR.STA", "WARFLD");
+bool loadData() {
+    return gFactors.load("Z.DAT")
+        && gEvent.loadEvent("KDEF")
+        && gEvent.loadTalk("TALK")
+        && gWarfieldData.load("WAR.STA", "WARFLD");
 }
 
 }

--- a/src/data/loader.hh
+++ b/src/data/loader.hh
@@ -21,6 +21,6 @@
 
 namespace hojy::data {
 
-void loadData();
+[[nodiscard]] bool loadData();
 
 }

--- a/src/data/warfielddata.cc
+++ b/src/data/warfielddata.cc
@@ -23,21 +23,38 @@
 #include "core/config.hh"
 #include "util/file.hh"
 #include <cstring>
+#include <utility>
 
 namespace hojy::data {
 
 WarfieldData gWarfieldData;
 
-void WarfieldData::load(const std::string &warsta, const std::string &warfld) {
-    util::File::getFileContent(core::config.dataFilePath(warsta), info_);
+bool WarfieldData::load(const std::string &warsta, const std::string &warfld) {
+    auto file = util::File::open(core::config.dataFilePath(warsta));
+    if (!file || file.size() == 0 || file.size() % sizeof(WarfieldInfo) != 0) { return false; }
+    std::vector<WarfieldInfo> info(static_cast<size_t>(file.size() / sizeof(WarfieldInfo)));
+    if (file.read(info.data(), info.size() * sizeof(WarfieldInfo)) != info.size() * sizeof(WarfieldInfo)) {
+        return false;
+    }
     GrpData::DataSet dset;
-    if (GrpData::loadData(warfld, dset)) {
-        layers_.resize(dset.size());
-        for (size_t i = 0; i < dset.size(); ++i) {
-            auto sz = std::min(sizeof(layers_[i].layers), dset[i].size());
-            memcpy(layers_[i].layers, dset[i].data(), sz);
+    if (!GrpData::loadData(warfld, dset)) { return false; }
+    std::vector<WarfieldLayers> layers(dset.size());
+    constexpr size_t layerSize = sizeof(std::int16_t) * data::WarFieldWidth * data::WarFieldHeight;
+    for (size_t i = 0; i < dset.size(); ++i) {
+        if (dset[i].size() > sizeof(layers[i].layers) || dset[i].size() % layerSize != 0) { return false; }
+        if (!dset[i].empty()) {
+            memcpy(layers[i].layers, dset[i].data(), dset[i].size());
         }
     }
+    for (const auto &warfield: info) {
+        if (warfield.warFieldId < 0 || static_cast<size_t>(warfield.warFieldId) >= layers.size()) {
+            return false;
+        }
+        if (dset[warfield.warFieldId].empty()) { return false; }
+    }
+    info_ = std::move(info);
+    layers_ = std::move(layers);
+    return true;
 }
 
 const WarfieldInfo *WarfieldData::info(std::int16_t id) const {

--- a/src/data/warfielddata.hh
+++ b/src/data/warfielddata.hh
@@ -42,7 +42,7 @@ struct WarfieldLayers {
 
 class WarfieldData {
 public:
-    void load(const std::string &warsta, const std::string &warfld);
+    [[nodiscard]] bool load(const std::string &warsta, const std::string &warfld);
     [[nodiscard]] size_t size() const { return info_.size(); }
     [[nodiscard]] const WarfieldInfo *info(std::int16_t id) const;
     [[nodiscard]] const WarfieldLayers *layers(std::int16_t id) const;

--- a/src/main.cc
+++ b/src/main.cc
@@ -28,15 +28,22 @@
 #include "mem/strings.hh"
 #include "scene/window.hh"
 
+#include <cstdlib>
+#include <filesystem>
+
 using namespace hojy;
 
 int main(int argc, char *argv[]) {
-    core::config.load("config.toml");
-    core::config.load(core::config.saveFilePath("options.toml"));
-    core::config.postLoad();
-    mem::gStrings.load("strings.toml");
+    if (!core::config.load("config.toml")) { return EXIT_FAILURE; }
+    const auto optionsFile = core::config.saveFilePath("options.toml");
+    std::error_code ec;
+    if (std::filesystem::is_regular_file(optionsFile, ec)) {
+        core::config.load(optionsFile);
+    }
+    if (!core::config.postLoad()) { return EXIT_FAILURE; }
+    if (!mem::gStrings.load("strings.toml")) { return EXIT_FAILURE; }
     core::config.fixOnTextLoaded();
-    data::loadData();
+    if (!data::loadData()) { return EXIT_FAILURE; }
     scene::Window win(core::config.windowWidth(), core::config.windowHeight());
     for (;;) {
         win.update();
@@ -54,6 +61,6 @@ eventStart:
 
 #ifdef _MSC_VER
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow) {
-    main(__argc, __argv);
+    return main(__argc, __argv);
 }
 #endif

--- a/src/mem/action.cc
+++ b/src/mem/action.cc
@@ -192,23 +192,6 @@ bool useItem(CharacterData *charInfo, std::int16_t itemId, std::map<PropType, st
     return true;
 }
 
-bool consumeNpcItem(CharacterData *charInfo, std::int16_t itemId) {
-    if (!charInfo) { return false; }
-    for (int i = 0; i < data::CarryItemCount; ++i) {
-        if (charInfo->item[i] != itemId || charInfo->itemCount[i] <= 0) { continue; }
-        if (--charInfo->itemCount[i] == 0) {
-            for (int j = i; j + 1 < data::CarryItemCount; ++j) {
-                charInfo->item[j] = charInfo->item[j + 1];
-                charInfo->itemCount[j] = charInfo->itemCount[j + 1];
-            }
-            charInfo->item[data::CarryItemCount - 1] = -1;
-            charInfo->itemCount[data::CarryItemCount - 1] = 0;
-        }
-        return true;
-    }
-    return false;
-}
-
 std::int16_t tryUseBagItem(CharacterData *charInfo, PropType type, std::int16_t value) {
     if (!charInfo) { return -1; }
     std::multimap<std::int16_t, std::int16_t> optionalItems;
@@ -259,19 +242,9 @@ bool useNpcItem(CharacterData *charInfo, std::int16_t itemId, std::map<PropType,
     if (!itemInfo) { return false; }
     if (!canUseItem(charInfo, itemInfo)) { return false; }
     for (int i = 0; i < data::CarryItemCount; ++i) {
-        if (charInfo->item[i] != itemId) { continue; }
+        if (charInfo->item[i] != itemId || charInfo->itemCount[i] <= 0) { continue; }
         if (!applyItemChanges(charInfo, itemInfo, changes)) { return false; }
-        if (--charInfo->itemCount[i] <= 0) {
-            if (i + 1 < data::CarryItemCount) {
-                memmove(charInfo->item + i, charInfo->item + i + 1,
-                        sizeof(std::int16_t) * data::CarryItemCount - i - 1);
-                memmove(charInfo->itemCount + i, charInfo->itemCount + i + 1,
-                        sizeof(std::int16_t) * data::CarryItemCount - i - 1);
-            }
-            charInfo->item[data::CarryItemCount - 1] = -1;
-            charInfo->itemCount[data::CarryItemCount - 1] = 0;
-        }
-        return true;
+        return consumeNpcItem(charInfo, itemId);
     }
     return false;
 }

--- a/src/mem/npcitem.cc
+++ b/src/mem/npcitem.cc
@@ -17,33 +17,29 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "serializable.hh"
+#include "action.hh"
 
-#include <streambuf>
-#include <sstream>
+#include <algorithm>
 
 namespace hojy::mem {
 
-struct MemBuf: std::streambuf {
-    MemBuf(const char *p, size_t size) {
-        auto *ptr = const_cast<char*>(p);
-        setg(ptr, ptr, ptr + size);
+bool consumeNpcItem(CharacterData *charInfo, std::int16_t itemId) {
+    if (!charInfo) { return false; }
+    for (int i = 0; i < data::CarryItemCount; ++i) {
+        if (charInfo->item[i] != itemId || charInfo->itemCount[i] <= 0) { continue; }
+        if (--charInfo->itemCount[i] == 0) {
+            std::move(charInfo->item + i + 1,
+                      charInfo->item + data::CarryItemCount,
+                      charInfo->item + i);
+            std::move(charInfo->itemCount + i + 1,
+                      charInfo->itemCount + data::CarryItemCount,
+                      charInfo->itemCount + i);
+            charInfo->item[data::CarryItemCount - 1] = -1;
+            charInfo->itemCount[data::CarryItemCount - 1] = 0;
+        }
+        return true;
     }
-};
-
-
-void Serializable::serialize(std::string &data) {
-    std::ostringstream stm;
-    *this >> stm;
-    data = std::move(stm.str());
-}
-
-bool Serializable::deserialize(const std::string &data) {
-    if (!validSerializedSize(data.size())) { return false; }
-    MemBuf buf(data.data(), data.size());
-    std::istream istm(&buf);
-    *this << istm;
-    return !istm.bad();
+    return false;
 }
 
 }

--- a/src/mem/savedata.cc
+++ b/src/mem/savedata.cc
@@ -21,6 +21,8 @@
 
 #include "data/grpdata.hh"
 
+#include <utility>
+
 namespace hojy::mem {
 
 SaveData gSaveData;
@@ -51,39 +53,45 @@ bool SaveData::load(int num) {
     if (rangerData.size() < 6) {
         return false;
     }
-    baseInfo.deserialize(rangerData[0]);
-    charInfo.deserialize(rangerData[1]);
-    itemInfo.deserialize(rangerData[2]);
-    subMapInfo.deserialize(rangerData[3]);
-    skillInfo.deserialize(rangerData[4]);
-    shopInfo.deserialize(rangerData[5]);
     if (!data::GrpData::loadData(sinFile, sinData, num > 0)) {
         return false;
-    }
-    size_t sz = sinData.size();
-    if (sz < subMapInfo.size()) {
-        return false;
-    }
-    subMapLayerInfo.resize(sz);
-    for (size_t i = 0; i < sz; ++i) {
-        subMapLayerInfo[i].deserialize(sinData[i]);
     }
     if (!data::GrpData::loadData(defFile, defData, num > 0)) {
         return false;
     }
-    sz = defData.size();
-    if (sz < subMapInfo.size()) {
+
+    SaveData loaded;
+    if (!loaded.baseInfo.deserialize(rangerData[0])
+        || !loaded.charInfo.deserialize(rangerData[1])
+        || !loaded.itemInfo.deserialize(rangerData[2])
+        || !loaded.subMapInfo.deserialize(rangerData[3])
+        || !loaded.skillInfo.deserialize(rangerData[4])
+        || !loaded.shopInfo.deserialize(rangerData[5])) {
         return false;
     }
-    subMapEventInfo.resize(sz);
-    for (size_t i = 0; i < sz; ++i) {
-        subMapEventInfo[i].deserialize(defData[i]);
+    const auto subMapCount = loaded.subMapInfo.size();
+    if (sinData.size() != subMapCount || defData.size() != subMapCount) {
+        return false;
     }
+    loaded.subMapLayerInfo.resize(subMapCount);
+    loaded.subMapEventInfo.resize(subMapCount);
+    for (size_t i = 0; i < subMapCount; ++i) {
+        if (!loaded.subMapLayerInfo[i].deserialize(sinData[i])
+            || !loaded.subMapEventInfo[i].deserialize(defData[i])) {
+            return false;
+        }
+    }
+
+    *this = std::move(loaded);
     gBag.syncFromSave();
     return true;
 }
 
 bool SaveData::save(int num) {
+    if (subMapLayerInfo.size() != subMapInfo.size()
+        || subMapEventInfo.size() != subMapInfo.size()) {
+        return false;
+    }
     gBag.syncToSave();
     std::string rangerFile, sinFile, defFile;
     buildSaveFilename(num, rangerFile, sinFile, defFile);
@@ -106,7 +114,7 @@ bool SaveData::save(int num) {
     if (!data::GrpData::saveData(sinFile, data, true)) {
         return false;
     }
-    sz = subMapLayerInfo.size();
+    sz = subMapEventInfo.size();
     data.resize(sz);
     for (size_t i = 0; i < sz; ++i) {
         subMapEventInfo[i].serialize(data[i]);

--- a/src/mem/serializable.hh
+++ b/src/mem/serializable.hh
@@ -29,9 +29,12 @@ class Serializable {
 public:
     virtual ~Serializable() = default;
     void serialize(std::string&);
-    void deserialize(const std::string&);
+    [[nodiscard]] bool deserialize(const std::string&);
     virtual Serializable &operator>>(std::ostream &ostm) { return *this; }
     virtual Serializable &operator<<(std::istream &istm) { return *this; }
+
+protected:
+    [[nodiscard]] virtual bool validSerializedSize(size_t size) const { return true; }
 };
 
 template<typename T>
@@ -50,7 +53,10 @@ public:
     }
 
 private:
-    T data_;
+    [[nodiscard]] bool validSerializedSize(size_t size) const override { return size == sizeof(T); }
+
+private:
+    T data_{};
 };
 
 template<typename T>
@@ -70,7 +76,7 @@ public:
     Serializable &operator<<(std::istream &istm) override {
         data_.clear();
         while (!istm.eof()) {
-            T data;
+            T data{};
             istm.read(reinterpret_cast<char *>(&data), sizeof(data));
             if (!istm.fail()) {
                 data_.emplace_back(data);
@@ -78,6 +84,9 @@ public:
         }
         return *this;
     }
+
+private:
+    [[nodiscard]] bool validSerializedSize(size_t size) const override { return size % sizeof(T) == 0; }
 
 private:
     std::vector<T> data_;

--- a/src/mem/strings.cc
+++ b/src/mem/strings.cc
@@ -26,31 +26,43 @@
 #include "util/file.hh"
 #include <external/toml.hpp>
 
+#include <utility>
+
 namespace hojy::mem {
+
+namespace {
+
+constexpr size_t RequiredTextCount = 138;
+
+}
 
 Strings gStrings;
 
-void Strings::load(const std::string &filename) {
+bool Strings::load(const std::string &filename) {
     toml::table tbl;
     try {
         tbl = toml::parse(util::File::getFileContent(core::config.dataFilePath(filename)));
     } catch (const toml::parse_error &err) {
         std::cerr << "Parsing failed: " << err << std::endl;
-        return;
+        return false;
     }
     auto arr = tbl["strings"].as_array();
-    strings_[Text].reserve(arr->size());
+    if (!arr || arr->size() < RequiredTextCount) { return false; }
+    std::vector<std::wstring> strings;
+    strings.reserve(arr->size());
     for (auto &n: *arr) {
-        strings_[Text].emplace_back(util::Utf8Conv::toUnicode(n.value_or<std::string>("")));
+        strings.emplace_back(util::Utf8Conv::toUnicode(n.value_or<std::string>("")));
     }
     if (core::config.simplifiedChinese()) {
-        auto backupCharName = strings_[Text][0];
-        for (auto &n: strings_[Text]) {
+        auto backupCharName = strings[0];
+        for (auto &n: strings) {
             n = util::trad2SimpConv.convert(n);
         }
         /* allow traditional chinese chars in default user name */
-        strings_[Text][0] = backupCharName;
+        strings[0] = backupCharName;
     }
+    strings_[Text] = std::move(strings);
+    return true;
 }
 
 void Strings::saveDataLoaded() {

--- a/src/mem/strings.hh
+++ b/src/mem/strings.hh
@@ -40,7 +40,7 @@ public:
         StringsMax,
     };
 
-    void load(const std::string &filename);
+    [[nodiscard]] bool load(const std::string &filename);
     void saveDataLoaded();
     const std::wstring &operator()(Type type, std::int16_t index) {
         static const std::wstring empty;

--- a/src/scene/window.cc
+++ b/src/scene/window.cc
@@ -143,8 +143,9 @@ Window::Window(int w, int h) : width_(w), height_(h), freq_(SDL_GetPerformanceFr
     }
     itemTexture_->unlock();
     SDL_ShowWindow(win);
-    audio::gMixer.init(3);
-    audio::gMixer.pause(false);
+    if (audio::gMixer.init(3)) {
+        audio::gMixer.pause(false);
+    }
     title();
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,63 @@ target_include_directories(battle_turn_order_tests PRIVATE
 target_link_libraries(battle_turn_order_tests PRIVATE hojy_battle)
 add_test(NAME battle_turn_order_tests COMMAND battle_turn_order_tests)
 
+add_executable(npc_item_tests
+    mem/npc_item_tests.cc
+    ${PROJECT_SOURCE_DIR}/src/mem/npcitem.cc)
+target_include_directories(npc_item_tests PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(npc_item_tests PROPERTIES CXX_STANDARD 17)
+add_test(NAME npc_item_tests COMMAND npc_item_tests)
+
+add_executable(persistence_tests
+    data/persistence_tests.cc
+    data/config_stub.cc
+    ${PROJECT_SOURCE_DIR}/src/data/event.cc
+    ${PROJECT_SOURCE_DIR}/src/data/grpdata.cc
+    ${PROJECT_SOURCE_DIR}/src/data/warfielddata.cc
+    ${PROJECT_SOURCE_DIR}/src/mem/bag.cc
+    ${PROJECT_SOURCE_DIR}/src/mem/savedata.cc
+    ${PROJECT_SOURCE_DIR}/src/mem/serializable.cc
+    ${PROJECT_SOURCE_DIR}/src/mem/strings.cc
+    ${PROJECT_SOURCE_DIR}/src/util/conv.cc
+    ${PROJECT_SOURCE_DIR}/src/util/file.cc)
+target_include_directories(persistence_tests PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(persistence_tests PROPERTIES CXX_STANDARD 17)
+if(CMAKE_COMPILER_IS_GNUCXX)
+    target_link_libraries(persistence_tests PRIVATE stdc++fs)
+endif()
+add_test(NAME persistence_tests COMMAND persistence_tests)
+
+add_executable(audio_channel_tests
+    audio/channel_tests.cc
+    ${PROJECT_SOURCE_DIR}/src/audio/channel.cc
+    ${PROJECT_SOURCE_DIR}/src/audio/channelwav.cc
+    ${PROJECT_SOURCE_DIR}/src/util/file.cc)
+target_include_directories(audio_channel_tests PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(audio_channel_tests PRIVATE SDL_MAIN_HANDLED)
+target_link_libraries(audio_channel_tests PRIVATE SDL2)
+set_target_properties(audio_channel_tests PROPERTIES CXX_STANDARD 17)
+add_custom_command(TARGET audio_channel_tests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:SDL2>
+        $<TARGET_FILE_DIR:audio_channel_tests>)
+add_test(NAME audio_channel_tests COMMAND audio_channel_tests)
+
+set(STARTUP_EMPTY_DIR ${CMAKE_CURRENT_BINARY_DIR}/startup-empty)
+file(MAKE_DIRECTORY ${STARTUP_EMPTY_DIR})
+add_test(
+    NAME startup_missing_config_test
+    COMMAND ${CMAKE_COMMAND}
+        -DEXECUTABLE=$<TARGET_FILE:HeroesOfJinYongMain>
+        -DWORKING_DIRECTORY=${STARTUP_EMPTY_DIR}
+        -DEXPECTED_EXIT=1
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/startup/expect_exit.cmake)
+
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 add_test(
     NAME reverse_manifest_tests

--- a/tests/audio/channel_tests.cc
+++ b/tests/audio/channel_tests.cc
@@ -1,0 +1,164 @@
+/*
+ * Heroes of Jin Yong.
+ * A reimplementation of the DOS game `The legend of Jin Yong Heroes`.
+ * Copyright (C) 2021, Soar Qin<soarchin@gmail.com>
+ */
+
+#include "audio/channelwav.hh"
+#include "audio/resampler.hh"
+#include "test_support.hh"
+
+#include <SDL.h>
+
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace hojy::audio {
+
+Mixer::~Mixer() = default;
+
+Mixer::DataType Mixer::convertDataType(std::uint16_t type) {
+    switch (type) {
+    case 0:return I16;
+    case AUDIO_F32:return F32;
+    case AUDIO_S32:return I32;
+    case AUDIO_S16:return I16;
+    default:return InvalidType;
+    }
+}
+
+std::uint16_t Mixer::convertType(Mixer::DataType type) {
+    switch (type) {
+    case I16:return AUDIO_S16;
+    case I32:return AUDIO_S32;
+    default:return AUDIO_F32;
+    }
+}
+
+size_t Mixer::dataTypeToSize(Mixer::DataType type) {
+    switch (type) {
+    case F32:
+    case I32:return 4;
+    case F64:return 8;
+    case I16:return 2;
+    default:return 1;
+    }
+}
+
+Resampler::Resampler(std::uint32_t channels, double sampleRateIn, double sampleRateOut,
+                     Mixer::DataType typeIn, Mixer::DataType typeOut) {
+    (void)channels;
+    (void)sampleRateIn;
+    (void)sampleRateOut;
+    (void)typeIn;
+    (void)typeOut;
+}
+
+Resampler::~Resampler() = default;
+
+void Resampler::setInputCallback(InputCallback callback) {
+    inputCB_ = std::move(callback);
+}
+
+size_t Resampler::read(void *data, size_t size) {
+    (void)data;
+    (void)size;
+    return 0;
+}
+
+}
+
+namespace {
+
+void append16(std::vector<std::uint8_t> &data, std::uint16_t value) {
+    data.push_back(static_cast<std::uint8_t>(value));
+    data.push_back(static_cast<std::uint8_t>(value >> 8));
+}
+
+void append32(std::vector<std::uint8_t> &data, std::uint32_t value) {
+    append16(data, static_cast<std::uint16_t>(value));
+    append16(data, static_cast<std::uint16_t>(value >> 16));
+}
+
+void appendTag(std::vector<std::uint8_t> &data, const char *tag) {
+    data.insert(data.end(), tag, tag + 4);
+}
+
+void writeMonoU8Wav(const std::filesystem::path &filename) {
+    const std::array<std::uint8_t, 2> samples = {0, 255};
+    std::vector<std::uint8_t> data;
+    appendTag(data, "RIFF");
+    append32(data, 36 + samples.size());
+    appendTag(data, "WAVE");
+    appendTag(data, "fmt ");
+    append32(data, 16);
+    append16(data, 1);
+    append16(data, 1);
+    append32(data, 8000);
+    append32(data, 8000);
+    append16(data, 1);
+    append16(data, 8);
+    appendTag(data, "data");
+    append32(data, samples.size());
+    data.insert(data.end(), samples.begin(), samples.end());
+
+    std::ofstream file(filename, std::ios::binary);
+    file.write(reinterpret_cast<const char *>(data.data()), static_cast<std::streamsize>(data.size()));
+    if (!file) { throw std::runtime_error("failed to write wav fixture"); }
+}
+
+void wavTailAndReload() {
+    const auto directory = std::filesystem::temp_directory_path() / "hojy-audio-channel-tests";
+    std::error_code ec;
+    std::filesystem::remove_all(directory, ec);
+    std::filesystem::create_directories(directory);
+    const auto valid = directory / "valid.wav";
+    const auto invalid = directory / "invalid.wav";
+    writeMonoU8Wav(valid);
+    {
+        std::ofstream file(invalid, std::ios::binary);
+        file << "not a wav";
+    }
+
+    hojy::audio::Mixer mixer;
+    hojy::audio::ChannelWav channel(&mixer, valid.string());
+    HOJY_CHECK_EQ(channel.ok(), true);
+
+    std::array<std::uint8_t, 16> output;
+    output.fill(0xCD);
+    HOJY_CHECK_EQ(channel.readData(output.data(), output.size()), 8U);
+    for (size_t i = 8; i < output.size(); ++i) {
+        HOJY_CHECK_EQ(output[i], 0xCD);
+    }
+
+    channel.reset();
+    channel.setRepeat(true);
+    std::array<std::uint8_t, 12> repeated{};
+    HOJY_CHECK_EQ(channel.readData(repeated.data(), repeated.size()), repeated.size());
+    for (size_t i = 0; i < 4; ++i) {
+        HOJY_CHECK_EQ(repeated[i], repeated[i + 8]);
+    }
+
+    channel.load(invalid.string());
+    HOJY_CHECK_EQ(channel.ok(), false);
+    channel.load(valid.string());
+    HOJY_CHECK_EQ(channel.ok(), true);
+
+    std::filesystem::remove_all(directory, ec);
+}
+
+}
+
+int main() {
+    try {
+        wavTailAndReload();
+    } catch (const std::exception &error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/tests/data/config_stub.cc
+++ b/tests/data/config_stub.cc
@@ -1,0 +1,15 @@
+#include "core/config.hh"
+
+namespace hojy::core {
+
+Config config;
+
+std::string Config::dataFilePath(const std::string &filename) const {
+    return filename;
+}
+
+std::string Config::saveFilePath(const std::string &filename) const {
+    return filename;
+}
+
+}

--- a/tests/data/persistence_tests.cc
+++ b/tests/data/persistence_tests.cc
@@ -1,0 +1,287 @@
+/*
+ * Heroes of Jin Yong.
+ * A reimplementation of the DOS game `The legend of Jin Yong Heroes`.
+ * Copyright (C) 2021, Soar Qin<soarchin@gmail.com>
+ */
+
+#include "data/event.hh"
+#include "data/grpdata.hh"
+#include "data/warfielddata.hh"
+#include "mem/bag.hh"
+#include "mem/savedata.hh"
+#include "mem/serializable.hh"
+#include "mem/strings.hh"
+#include "test_support.hh"
+
+#include <array>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+class ScopedTempDirectory {
+public:
+    ScopedTempDirectory(): oldPath_(std::filesystem::current_path()) {
+        const auto suffix = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+        path_ = std::filesystem::temp_directory_path() / ("hojy-persistence-" + std::to_string(suffix));
+        std::filesystem::create_directories(path_);
+        std::filesystem::current_path(path_);
+    }
+
+    ~ScopedTempDirectory() {
+        std::error_code ec;
+        std::filesystem::current_path(oldPath_, ec);
+        std::filesystem::remove_all(path_, ec);
+    }
+
+private:
+    std::filesystem::path oldPath_, path_;
+};
+
+template<typename T>
+std::string asBytes(const T &value) {
+    return {reinterpret_cast<const char *>(&value), sizeof(value)};
+}
+
+void writeBytes(const std::string &filename, const std::string &data) {
+    std::ofstream file(filename, std::ios::binary);
+    file.write(data.data(), static_cast<std::streamsize>(data.size()));
+    if (!file) { throw std::runtime_error("failed to write " + filename); }
+}
+
+void writeOffsets(const std::string &filename, const std::vector<std::uint32_t> &offsets) {
+    std::ofstream file(filename, std::ios::binary);
+    file.write(reinterpret_cast<const char *>(offsets.data()),
+               static_cast<std::streamsize>(offsets.size() * sizeof(std::uint32_t)));
+    if (!file) { throw std::runtime_error("failed to write " + filename); }
+}
+
+void serializableRejectsInvalidSizes() {
+    hojy::mem::SerializableStruct<std::uint32_t> scalar;
+    const std::uint32_t value = 0x12345678;
+    HOJY_CHECK_EQ(scalar.deserialize(asBytes(value)), true);
+    HOJY_CHECK_EQ(*scalar.operator->(), value);
+    HOJY_CHECK_EQ(scalar.deserialize(std::string(sizeof(value) - 1, '\0')), false);
+    HOJY_CHECK_EQ(*scalar.operator->(), value);
+
+    hojy::mem::SerializableStructVec<std::uint16_t> values;
+    const std::uint16_t initial[] = {7, 9};
+    HOJY_CHECK_EQ(values.deserialize(std::string(reinterpret_cast<const char *>(initial), sizeof(initial))), true);
+    HOJY_CHECK_EQ(values.size(), 2U);
+    HOJY_CHECK_EQ(values.deserialize(std::string(3, '\0')), false);
+    HOJY_CHECK_EQ(values.size(), 2U);
+}
+
+void grpDataValidatesOffsets() {
+    using hojy::data::GrpData;
+    const GrpData::DataSet expected = {"ab", "", "cde"};
+    HOJY_CHECK_EQ(GrpData::saveData("GOOD", expected), true);
+    GrpData::DataSet loaded;
+    HOJY_CHECK_EQ(GrpData::loadData("GOOD", loaded), true);
+    HOJY_CHECK_EQ(loaded, expected);
+
+    loaded = {"unchanged"};
+    writeBytes("BAD_ALIGN.IDX", "abc");
+    writeBytes("BAD_ALIGN.GRP", "abc");
+    HOJY_CHECK_EQ(GrpData::loadData("BAD_ALIGN", loaded), false);
+    HOJY_CHECK_EQ(loaded, GrpData::DataSet{"unchanged"});
+
+    writeOffsets("BACKWARD.IDX", {2, 1});
+    writeBytes("BACKWARD.GRP", "ab");
+    HOJY_CHECK_EQ(GrpData::loadData("BACKWARD", loaded), false);
+    HOJY_CHECK_EQ(loaded, GrpData::DataSet{"unchanged"});
+
+    writeOffsets("PAST_END.IDX", {3});
+    writeBytes("PAST_END.GRP", "ab");
+    HOJY_CHECK_EQ(GrpData::loadData("PAST_END", loaded), false);
+    HOJY_CHECK_EQ(loaded, GrpData::DataSet{"unchanged"});
+
+    writeOffsets("TRAILING_DATA.IDX", {1});
+    writeBytes("TRAILING_DATA.GRP", "ab");
+    HOJY_CHECK_EQ(GrpData::loadData("TRAILING_DATA", loaded), false);
+    HOJY_CHECK_EQ(loaded, GrpData::DataSet{"unchanged"});
+
+    writeBytes("EMPTY_INDEX.IDX", "");
+    writeBytes("EMPTY_INDEX.GRP", "ab");
+    HOJY_CHECK_EQ(GrpData::loadData("EMPTY_INDEX", loaded), false);
+    HOJY_CHECK_EQ(loaded, GrpData::DataSet{"unchanged"});
+
+    writeOffsets("ZERO_END.IDX", {0});
+    writeBytes("ZERO_END.GRP", "abc");
+    HOJY_CHECK_EQ(GrpData::loadData("ZERO_END", loaded), true);
+    HOJY_CHECK_EQ(loaded, GrpData::DataSet{"abc"});
+
+    writeOffsets("ZERO_MIDDLE.IDX", {0, 3});
+    writeBytes("ZERO_MIDDLE.GRP", "abc");
+    HOJY_CHECK_EQ(GrpData::loadData("ZERO_MIDDLE", loaded), false);
+    HOJY_CHECK_EQ(loaded, GrpData::DataSet{"abc"});
+    HOJY_CHECK_EQ(GrpData::saveData("LEADING_EMPTY", {"", "abc"}), false);
+    HOJY_CHECK_EQ(std::filesystem::exists("LEADING_EMPTY.IDX"), false);
+}
+
+void eventRejectsOddBytecode() {
+    using hojy::data::GrpData;
+    const std::int16_t bytecode[] = {1, 2};
+    HOJY_CHECK_EQ(GrpData::saveData("EVENT", {std::string(reinterpret_cast<const char *>(bytecode), sizeof(bytecode))}), true);
+    hojy::data::Event event;
+    HOJY_CHECK_EQ(event.loadEvent("EVENT"), true);
+    HOJY_CHECK_EQ(event.event(0).size(), 2U);
+
+    HOJY_CHECK_EQ(GrpData::saveData("EVENT", {std::string(3, '\1')}), true);
+    HOJY_CHECK_EQ(event.loadEvent("EVENT"), false);
+    HOJY_CHECK_EQ(event.event(0).size(), 2U);
+    HOJY_CHECK_EQ(event.event(0)[0], 1);
+}
+
+void warfieldDataAcceptsSharedPartialMaps() {
+    using hojy::data::GrpData;
+    std::array<hojy::data::WarfieldInfo, 2> info{};
+    info[0].id = 10;
+    info[0].warFieldId = 0;
+    info[1].id = 11;
+    info[1].warFieldId = 0;
+    writeBytes("WAR.STA", std::string(reinterpret_cast<const char *>(info.data()), sizeof(info)));
+
+    std::vector<std::int16_t> map(hojy::data::WarFieldWidth * hojy::data::WarFieldHeight, 7);
+    HOJY_CHECK_EQ(GrpData::saveData("WARFLD", {
+        std::string(reinterpret_cast<const char *>(map.data()), map.size() * sizeof(std::int16_t))
+    }), true);
+
+    hojy::data::WarfieldData warfields;
+    HOJY_CHECK_EQ(warfields.load("WAR.STA", "WARFLD"), true);
+    HOJY_CHECK_EQ(warfields.size(), 2U);
+    HOJY_CHECK_EQ(warfields.layers(0)->layers[0][0], 7);
+    HOJY_CHECK_EQ(warfields.layers(0)->layers[1][0], 0);
+
+    info[1].warFieldId = 1;
+    writeBytes("WAR.STA", std::string(reinterpret_cast<const char *>(info.data()), sizeof(info)));
+    HOJY_CHECK_EQ(warfields.load("WAR.STA", "WARFLD"), false);
+    HOJY_CHECK_EQ(warfields.size(), 2U);
+    HOJY_CHECK_EQ(warfields.info(1)->warFieldId, 0);
+
+    info[1].warFieldId = 0;
+    writeBytes("WAR.STA", std::string(reinterpret_cast<const char *>(info.data()), sizeof(info)));
+    HOJY_CHECK_EQ(GrpData::saveData("WARFLD", {std::string(sizeof(std::int16_t), '\0')}), true);
+    HOJY_CHECK_EQ(warfields.load("WAR.STA", "WARFLD"), false);
+    HOJY_CHECK_EQ(warfields.layers(0)->layers[0][0], 7);
+
+    HOJY_CHECK_EQ(GrpData::saveData("WARFLD", {""}), true);
+    HOJY_CHECK_EQ(warfields.load("WAR.STA", "WARFLD"), false);
+    HOJY_CHECK_EQ(warfields.layers(0)->layers[0][0], 7);
+}
+
+void stringsRequireAllUiEntries() {
+    std::string content = "strings = [\n";
+    for (int i = 0; i < 138; ++i) {
+        content += "    \"text" + std::to_string(i) + "\",\n";
+    }
+    content += "]\n";
+    writeBytes("strings.toml", content);
+
+    hojy::mem::Strings strings;
+    HOJY_CHECK_EQ(strings.load("strings.toml"), true);
+    HOJY_CHECK_EQ(strings(hojy::mem::Strings::Text, 137), L"text137");
+
+    writeBytes("strings.toml", "strings = [\"truncated\"]\n");
+    HOJY_CHECK_EQ(strings.load("strings.toml"), false);
+    HOJY_CHECK_EQ(strings(hojy::mem::Strings::Text, 137), L"text137");
+}
+
+hojy::mem::SaveData makeSaveData(std::int16_t mainX, std::int16_t itemId, std::int16_t itemCount) {
+    hojy::mem::SaveData data;
+    auto &base = *data.baseInfo.operator->();
+    base.mainX = mainX;
+    for (auto &member: base.members) { member = -1; }
+    for (auto &item: base.items) { item = {-1, 0}; }
+    base.items[0] = {itemId, itemCount};
+
+    hojy::mem::SubMapData subMap{};
+    HOJY_CHECK_EQ(data.subMapInfo.deserialize(asBytes(subMap)), true);
+    data.subMapLayerInfo.resize(1);
+    data.subMapEventInfo.resize(1);
+    return data;
+}
+
+void writeSaveSlot(int slot, hojy::mem::SaveData &data, bool writeEvents, size_t layerCount = 1) {
+    using hojy::data::GrpData;
+    GrpData::DataSet ranger(6);
+    data.baseInfo.serialize(ranger[0]);
+    data.charInfo.serialize(ranger[1]);
+    data.itemInfo.serialize(ranger[2]);
+    data.subMapInfo.serialize(ranger[3]);
+    data.skillInfo.serialize(ranger[4]);
+    data.shopInfo.serialize(ranger[5]);
+    HOJY_CHECK_EQ(GrpData::saveData("R" + std::to_string(slot), ranger, true), true);
+
+    GrpData::DataSet layers(layerCount);
+    for (size_t i = 0; i < layerCount; ++i) {
+        data.subMapLayerInfo[0].serialize(layers[i]);
+    }
+    HOJY_CHECK_EQ(GrpData::saveData("S" + std::to_string(slot), layers, true), true);
+
+    if (writeEvents) {
+        GrpData::DataSet events(1);
+        data.subMapEventInfo[0].serialize(events[0]);
+        HOJY_CHECK_EQ(GrpData::saveData("D" + std::to_string(slot), events, true), true);
+    }
+}
+
+void saveDataLoadsTransactionally() {
+    auto first = makeSaveData(111, 1, 5);
+    writeSaveSlot(1, first, true);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.load(1), true);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.baseInfo->mainX, 111);
+    HOJY_CHECK_EQ(hojy::mem::gBag[1], 5);
+
+    auto missingEvents = makeSaveData(222, 2, 9);
+    writeSaveSlot(2, missingEvents, false);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.load(2), false);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.baseInfo->mainX, 111);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.subMapLayerInfo.size(), 1U);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.subMapEventInfo.size(), 1U);
+    HOJY_CHECK_EQ(hojy::mem::gBag[1], 5);
+    HOJY_CHECK_EQ(hojy::mem::gBag[2], 0);
+
+    auto extraLayer = makeSaveData(333, 3, 7);
+    writeSaveSlot(2, extraLayer, true, 2);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.load(2), false);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.baseInfo->mainX, 111);
+    HOJY_CHECK_EQ(hojy::mem::gBag[1], 5);
+}
+
+void saveRejectsMismatchedCollections() {
+    hojy::mem::gSaveData.subMapLayerInfo.resize(2);
+    hojy::mem::gSaveData.subMapEventInfo.resize(1);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.save(3), false);
+    HOJY_CHECK_EQ(std::filesystem::exists("R3.IDX"), false);
+
+    const std::array<hojy::mem::SubMapData, 2> subMaps{};
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.subMapInfo.deserialize(
+        std::string(reinterpret_cast<const char *>(subMaps.data()), sizeof(subMaps))), true);
+    hojy::mem::gSaveData.subMapEventInfo.resize(2);
+    HOJY_CHECK_EQ(hojy::mem::gSaveData.save(3), true);
+    HOJY_CHECK_EQ(std::filesystem::file_size("D3.IDX"), sizeof(std::uint32_t) * 2);
+}
+
+}
+
+int main() {
+    try {
+        ScopedTempDirectory tempDirectory;
+        serializableRejectsInvalidSizes();
+        grpDataValidatesOffsets();
+        eventRejectsOddBytecode();
+        warfieldDataAcceptsSharedPartialMaps();
+        stringsRequireAllUiEntries();
+        saveDataLoadsTransactionally();
+        saveRejectsMismatchedCollections();
+    } catch (const std::exception &error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/tests/data/persistence_tests.cc
+++ b/tests/data/persistence_tests.cc
@@ -115,10 +115,15 @@ void grpDataValidatesOffsets() {
     HOJY_CHECK_EQ(GrpData::loadData("ZERO_END", loaded), true);
     HOJY_CHECK_EQ(loaded, GrpData::DataSet{"abc"});
 
+    writeOffsets("ZERO_PADDING.IDX", {3, 0, 0});
+    writeBytes("ZERO_PADDING.GRP", "abc");
+    HOJY_CHECK_EQ(GrpData::loadData("ZERO_PADDING", loaded), true);
+    HOJY_CHECK_EQ(loaded, (GrpData::DataSet{"abc", "", ""}));
+
     writeOffsets("ZERO_MIDDLE.IDX", {0, 3});
     writeBytes("ZERO_MIDDLE.GRP", "abc");
     HOJY_CHECK_EQ(GrpData::loadData("ZERO_MIDDLE", loaded), false);
-    HOJY_CHECK_EQ(loaded, GrpData::DataSet{"abc"});
+    HOJY_CHECK_EQ(loaded, (GrpData::DataSet{"abc", "", ""}));
     HOJY_CHECK_EQ(GrpData::saveData("LEADING_EMPTY", {"", "abc"}), false);
     HOJY_CHECK_EQ(std::filesystem::exists("LEADING_EMPTY.IDX"), false);
 }

--- a/tests/mem/npc_item_tests.cc
+++ b/tests/mem/npc_item_tests.cc
@@ -1,0 +1,63 @@
+/*
+ * Heroes of Jin Yong.
+ * A reimplementation of the DOS game `The legend of Jin Yong Heroes`.
+ * Copyright (C) 2021, Soar Qin<soarchin@gmail.com>
+ */
+
+#include "mem/action.hh"
+#include "test_support.hh"
+
+#include <iostream>
+
+namespace {
+
+hojy::mem::CharacterData carriedItems() {
+    hojy::mem::CharacterData character{};
+    for (int i = 0; i < hojy::data::CarryItemCount; ++i) {
+        character.item[i] = static_cast<std::int16_t>(10 + i);
+        character.itemCount[i] = 1;
+    }
+    return character;
+}
+
+void removesEverySlotSafely() {
+    for (int slot = 0; slot < hojy::data::CarryItemCount; ++slot) {
+        auto character = carriedItems();
+        HOJY_CHECK_EQ(hojy::mem::consumeNpcItem(&character, character.item[slot]), true);
+        for (int i = 0; i < slot; ++i) {
+            HOJY_CHECK_EQ(character.item[i], 10 + i);
+            HOJY_CHECK_EQ(character.itemCount[i], 1);
+        }
+        for (int i = slot; i + 1 < hojy::data::CarryItemCount; ++i) {
+            HOJY_CHECK_EQ(character.item[i], 11 + i);
+            HOJY_CHECK_EQ(character.itemCount[i], 1);
+        }
+        HOJY_CHECK_EQ(character.item[hojy::data::CarryItemCount - 1], -1);
+        HOJY_CHECK_EQ(character.itemCount[hojy::data::CarryItemCount - 1], 0);
+    }
+}
+
+void decrementsAndRejectsEmptySlots() {
+    auto character = carriedItems();
+    character.itemCount[1] = 2;
+    HOJY_CHECK_EQ(hojy::mem::consumeNpcItem(&character, character.item[1]), true);
+    HOJY_CHECK_EQ(character.item[1], 11);
+    HOJY_CHECK_EQ(character.itemCount[1], 1);
+
+    character.itemCount[1] = 0;
+    HOJY_CHECK_EQ(hojy::mem::consumeNpcItem(&character, character.item[1]), false);
+    HOJY_CHECK_EQ(hojy::mem::consumeNpcItem(nullptr, 11), false);
+}
+
+}
+
+int main() {
+    try {
+        removesEverySlotSafely();
+        decrementsAndRejectsEmptySlots();
+    } catch (const std::exception &error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+    return 0;
+}

--- a/tests/startup/expect_exit.cmake
+++ b/tests/startup/expect_exit.cmake
@@ -1,0 +1,13 @@
+execute_process(
+    COMMAND "${EXECUTABLE}"
+    WORKING_DIRECTORY "${WORKING_DIRECTORY}"
+    RESULT_VARIABLE result
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error)
+
+if(NOT result STREQUAL EXPECTED_EXIT)
+    message(FATAL_ERROR
+        "Expected exit code ${EXPECTED_EXIT}, got ${result}.\n"
+        "stdout: ${output}\n"
+        "stderr: ${error}")
+endif()


### PR DESCRIPTION
## Summary

- validate save files, IDX/GRP resources, events, strings, factors, and warfield data before committing state
- fix NPC consumable removal and WAV tail, repeat, conversion, reload, and mixer lifecycle handling
- fail early when required startup configuration or resources are unavailable while keeping optional options non-fatal
- add repository guidance and regression tests for persistence, audio, NPC items, and startup failures
- preserve compatibility with zero-padded IDX tables such as `MMAP.IDX`

## Why

Several loaders accepted malformed or short data and could leave partially updated state. Audio paths also contained buffer-length, conversion, reload, and synchronization issues.

The initial IDX hardening treated zero offsets too strictly. Original `MMAP.IDX` files contain thousands of trailing zero entries, which caused `MMAP` loading to fail and `GlobalMap` to access an empty dataset. The follow-up fix accepts consecutive trailing zero entries while still rejecting nonzero offsets after the end marker.

## Impact

Runtime data failures now stop safely instead of corrupting existing state or entering partially initialized scenes. Original game resources, including zero-padded IDX tables and partial warfield layers, remain supported. Audio initialization can fail without preventing gameplay.

## Validation

- Debug build and CTest: 12/12 passed
- Release build and CTest: 12/12 passed
- Debug and Release startup smoke tests passed through `GlobalMap` construction
- all paired IDX/GRP files in the bundled resource directory satisfy the revised loader rules
- `git diff --check` passed